### PR TITLE
do not translate choice values

### DIFF
--- a/Form/EventListener/AttributeSubscriber.php
+++ b/Form/EventListener/AttributeSubscriber.php
@@ -102,6 +102,7 @@ class AttributeSubscriber implements EventSubscriberInterface
             }
 
             $type = 'choice';
+            $params['choice_translation_domain'] = false;
         } elseif (is_array($value)) {
             $value = null;
         }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": ">2.3.0",
+        "symfony/symfony": "~2.7",
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*"
     },


### PR DESCRIPTION
Choices are entered by end users, who do not know anything about
translations.
